### PR TITLE
1037U doesn't support encoding

### DIFF
--- a/src/i965_device_info.c
+++ b/src/i965_device_info.c
@@ -824,6 +824,7 @@ static void gen6_hw_codec_preinit(VADriverContextP ctx, struct hw_codec_info *co
  */
 const static char *gen7_cpu_hook_list[] =  {
 "Intel(R)Celeron(R)CPU1007U",
+"Intel(R)Celeron(R)CPU1037U",
 "Intel(R)Pentium(R)CPUG2130",
 };
 


### PR DESCRIPTION
1037U is recognized as Ivy Bridge, but actually 1037U doesn't
support encoding, so we have to add it into the cpu hook list.

Refer to https://github.com/01org/intel-vaapi-driver/issues/3 for more info.

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>