### PR TITLE
JPEG Encoder: support vaQuerySurfaceAttributes() pixel format

### DIFF
--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -5845,7 +5845,8 @@ i965_QuerySurfaceAttributes(VADriverContextP ctx,
             }
         } else if (obj_config->entrypoint == VAEntrypointEncSlice ||  /* encode */
                    obj_config->entrypoint == VAEntrypointVideoProc ||
-                   obj_config->entrypoint == VAEntrypointEncSliceLP) {
+                   obj_config->entrypoint == VAEntrypointEncSliceLP ||
+                   obj_config->entrypoint == VAEntrypointEncPicture) {
 
             if (obj_config->profile == VAProfileHEVCMain10) {
                 attribs[i].type = VASurfaceAttribPixelFormat;


### PR DESCRIPTION
When querying the surface attributes, using the JPEG encoder
(profile VAProfileJPEGBaseline, entrypoint VAEntrypointEncPicture)
the function doesn't return the available VASurfaceAttribPixelFormat
because it is not considered in the driver's code.

This patch proposes to return the default branch for encoders entry
points.

Signed-off-by: Víctor Manuel Jáquez Leal <vjaquez@igalia.com>