### PR TITLE
Update the README

### DIFF
--- a/README
+++ b/README
@@ -43,7 +43,9 @@ VP8     E   CHV+/BSW+
 HEVC    D   CHV+/BSW+
 HEVC    E   SKL+
 VP9     D   BXT+
+VP9     E   KBL+
 HEVC 10bit     D       BXT+
+HEVC 10bit     E       KBL+
 VP9 10bit      D       KBL+
 
 Requirements


### PR DESCRIPTION
Kaby Lake supports VP9 8bit encode and HEVC 10bit encode

This fixes https://github.com/01org/intel-vaapi-driver/issues/66

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>