### PR TITLE
configure.ac: check for AC_FUNC_ALLOCA

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # intel-vaapi-driver package version number
 m4_define([intel_vaapi_driver_major_version], [1])
 m4_define([intel_vaapi_driver_minor_version], [8])
-m4_define([intel_vaapi_driver_micro_version], [0])
+m4_define([intel_vaapi_driver_micro_version], [1])
 m4_define([intel_vaapi_driver_pre_version],   [1])
 m4_define([intel_vaapi_driver_version],
           [intel_vaapi_driver_major_version.intel_vaapi_driver_minor_version.intel_vaapi_driver_micro_version])

--- a/src/i965_decoder_utils.c
+++ b/src/i965_decoder_utils.c
@@ -23,7 +23,6 @@
 
 #include "sysdeps.h"
 #include <limits.h>
-#include <alloca.h>
 
 #include "intel_batchbuffer.h"
 #include "intel_media.h"
@@ -343,7 +342,7 @@ avc_get_first_mb_bit_offset_with_epb(
     if (buf_size > data_size)
         buf_size = data_size;
 
-    buf = alloca(buf_size);
+    buf = malloc(buf_size);
     ret = dri_bo_get_subdata(
         slice_data_bo, slice_param->slice_data_offset,
         buf_size, buf
@@ -354,6 +353,8 @@ avc_get_first_mb_bit_offset_with_epb(
         if (buf[i] == 0x03 && buf[i - 1] == 0x00 && buf[i - 2] == 0x00)
             i += 2, j++, n++;
     }
+
+    free(buf);
 
     out_slice_data_bit_offset = in_slice_data_bit_offset + n * 8;
 


### PR DESCRIPTION
Add AC_FUNC_ALLOCA and adjust src/i965_decoder_utils.c to properly include
relevant header files for alloca(3).

Some operating systems does not have <alloca.h> (e.g. NetBSD). This fixes
compilation on such systems.

Signed-off-by: Leonardo Taccari <iamleot@gmail.com>