### PR TITLE
Fix some possible garbage data after malloc in i965_create_buffer_int…

### DIFF
--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -2532,11 +2532,11 @@ i965_create_buffer_internal(VADriverContextP ctx,
         assert(buffer_store->buffer);
 
         if (!wrapper_flag) {
+            memset(buffer_store->buffer, 0, msize * num_elements);
             if (data)
                 memcpy(buffer_store->buffer, data, size * num_elements);
-            else
-                memset(buffer_store->buffer, 0, size * num_elements);
-        }
+        } else
+            memset(buffer_store->buffer, 0, 4);
     }
 
     buffer_store->num_elements = obj_buffer->num_elements;


### PR DESCRIPTION
…ernal func.

Fixes https://github.com/01org/intel-vaapi-driver/issues/82

Signed-off-by: Lim Siew Hoon <siew.hoon.lim@intel.com>