### PR TITLE
configure: change package tarball name to use hyphens

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_PREREQ([2.57])
 AC_INIT([intel_vaapi_driver],
         [intel_vaapi_driver_version],
         [https://github.com/01org/intel-vaapi-driver/issues/new],
-        [intel_vaapi_driver],
+        [intel-vaapi-driver],
         [https://github.com/01org/intel-vaapi-driver])
 AC_CONFIG_SRCDIR([Makefile.am])
 AM_INIT_AUTOMAKE([1.9 tar-ustar])


### PR DESCRIPTION
Compilation scripts on different distributions (i.e. arch, gentoo) rely
on the tarball name to use hyphens between words.

This patch will create tarballs with hyphenated names and keep the
legacy package naming

TEST="make dist, should produce intel-vaapi-driver.tar.*"

Fixes #85

Signed-off-by: Daniel Charles <daniel.charles@intel.com>