### PR TITLE
Avoid NULL pointer in avc_get_first_mb_bit_offset_with_epb()

### DIFF
--- a/src/i965_decoder_utils.c
+++ b/src/i965_decoder_utils.c
@@ -331,7 +331,7 @@ avc_get_first_mb_bit_offset_with_epb(
 {
     unsigned int in_slice_data_bit_offset = slice_param->slice_data_bit_offset;
     unsigned int out_slice_data_bit_offset;
-    unsigned int i, j, n, buf_size, data_size, header_size;
+    unsigned int i, j, n = 0, buf_size, data_size, header_size;
     uint8_t *buf;
     int ret;
 
@@ -343,6 +343,10 @@ avc_get_first_mb_bit_offset_with_epb(
         buf_size = data_size;
 
     buf = malloc(buf_size);
+
+    if (!buf)
+        goto out;
+
     ret = dri_bo_get_subdata(
         slice_data_bo, slice_param->slice_data_offset,
         buf_size, buf
@@ -356,6 +360,7 @@ avc_get_first_mb_bit_offset_with_epb(
 
     free(buf);
 
+out:
     out_slice_data_bit_offset = in_slice_data_bit_offset + n * 8;
 
     if (mode_flag == ENTROPY_CABAC)


### PR DESCRIPTION
This fixes https://github.com/01org/intel-vaapi-driver/issues/92

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>