### PR TITLE
Add the video encoder support for GLK

### DIFF
--- a/src/gen9_avc_encoder.c
+++ b/src/gen9_avc_encoder.c
@@ -2098,7 +2098,8 @@ gen9_avc_init_brc_const_data(VADriverContextP ctx,
         memcpy(data,(unsigned char *)gen9_avc_intra_scaling_factor,size * sizeof(unsigned char));
     }
 
-    if (IS_KBL(i965->intel.device_info))
+    if (IS_KBL(i965->intel.device_info)||
+        IS_GLK(i965->intel.device_info))
     {
         data += size;
 
@@ -2572,8 +2573,9 @@ gen9_avc_send_surface_brc_frame_update(VADriverContextP ctx,
     if (IS_SKL(i965->intel.device_info)||
         IS_BXT(i965->intel.device_info))
         is_g95 = 0;
-    else if (IS_KBL(i965->intel.device_info))
-        is_g95 = 1;
+    else if (IS_KBL(i965->intel.device_info)||
+             IS_GLK(i965->intel.device_info))
+             is_g95 = 1;
 
     /* brc history buffer*/
     gen9_add_buffer_gpe_surface(ctx,
@@ -3226,7 +3228,8 @@ gen9_avc_set_curbe_mbenc(VADriverContextP ctx,
 
         }
     }
-    else if (IS_KBL(i965->intel.device_info))
+    else if (IS_KBL(i965->intel.device_info)||
+             IS_GLK(i965->intel.device_info))
     {
         cmd.g95 = (gen95_avc_mbenc_curbe_data *)i965_gpe_context_map_curbe(gpe_context);
         if(!cmd.g95)
@@ -3766,8 +3769,9 @@ gen9_avc_send_surface_mbenc(VADriverContextP ctx,
     if (IS_SKL(i965->intel.device_info)||
         IS_BXT(i965->intel.device_info))
         is_g95 = 0;
-    else if (IS_KBL(i965->intel.device_info))
-        is_g95 = 1;
+    else if (IS_KBL(i965->intel.device_info)||
+             IS_GLK(i965->intel.device_info))
+             is_g95 = 1;
 
     obj_surface = encode_state->reconstructed_object;
 
@@ -5022,7 +5026,8 @@ gen9_avc_kernel_init_scaling(VADriverContextP ctx,
         kernel_param.curbe_size = sizeof(gen9_avc_scaling4x_curbe_data);
         kernel_param.inline_data_size = sizeof(gen9_avc_scaling4x_curbe_data);
     }
-    else if (IS_KBL(i965->intel.device_info))
+    else if (IS_KBL(i965->intel.device_info)||
+             IS_GLK(i965->intel.device_info))
     {
         kernel_param.curbe_size = sizeof(gen95_avc_scaling4x_curbe_data);
         kernel_param.inline_data_size = sizeof(gen95_avc_scaling4x_curbe_data);
@@ -5140,7 +5145,8 @@ gen9_avc_kernel_init_mbenc(VADriverContextP ctx,
         IS_BXT(i965->intel.device_info)) {
         curbe_size = sizeof(gen9_avc_mbenc_curbe_data);
     }
-    else if (IS_KBL(i965->intel.device_info)) {
+    else if (IS_KBL(i965->intel.device_info) ||
+             IS_GLK(i965->intel.device_info)) {
         curbe_size = sizeof(gen9_avc_mbenc_curbe_data);
     }
 
@@ -6210,7 +6216,8 @@ gen9_avc_kernel_init(VADriverContextP ctx,
     if (IS_SKL(i965->intel.device_info)||
         IS_BXT(i965->intel.device_info))
         generic_ctx->pfn_set_curbe_scaling4x = gen9_avc_set_curbe_scaling4x;
-    else if (IS_KBL(i965->intel.device_info))
+    else if (IS_KBL(i965->intel.device_info)||
+             IS_GLK(i965->intel.device_info))
         generic_ctx->pfn_set_curbe_scaling4x = gen95_avc_set_curbe_scaling4x;
 
 }
@@ -7809,7 +7816,8 @@ gen9_avc_vme_context_init(VADriverContextP ctx, struct intel_encoder_context *en
         generic_ctx->enc_kernel_ptr = (void *)skl_avc_encoder_kernels;
         generic_ctx->enc_kernel_size = sizeof(skl_avc_encoder_kernels);
     }
-    else if (IS_KBL(i965->intel.device_info)) {
+    else if (IS_KBL(i965->intel.device_info) ||
+             IS_GLK(i965->intel.device_info)) {
         generic_ctx->enc_kernel_ptr = (void *)kbl_avc_encoder_kernels;
         generic_ctx->enc_kernel_size = sizeof(kbl_avc_encoder_kernels);
     }
@@ -8004,7 +8012,8 @@ gen9_avc_vme_context_init(VADriverContextP ctx, struct intel_encoder_context *en
         avc_state->brc_const_data_surface_width = 64;
         avc_state->brc_const_data_surface_height = 44;
     }
-    else if (IS_KBL(i965->intel.device_info)) {
+    else if (IS_KBL(i965->intel.device_info)||
+             IS_GLK(i965->intel.device_info)) {
         avc_state->brc_const_data_surface_width = 64;
         avc_state->brc_const_data_surface_height = 53;
         //gen95

--- a/src/gen9_vdenc.c
+++ b/src/gen9_vdenc.c
@@ -2993,7 +2993,8 @@ gen9_vdenc_mfx_avc_insert_slice_packed_data(VADriverContextP ctx,
         /* For the Normal H264 */
 
         if (slice_index &&
-            IS_KBL(i965->intel.device_info)) {
+            (IS_KBL(i965->intel.device_info) ||
+             IS_GLK(i965->intel.device_info))) {
             saved_macroblock_address = slice_params->macroblock_address;
             slice_params->macroblock_address = 0;
         }
@@ -3006,7 +3007,8 @@ gen9_vdenc_mfx_avc_insert_slice_packed_data(VADriverContextP ctx,
         slice_header1 = slice_header;
 
         if (slice_index &&
-            IS_KBL(i965->intel.device_info)) {
+            (IS_KBL(i965->intel.device_info) ||
+             IS_GLK(i965->intel.device_info))) {
             slice_params->macroblock_address = saved_macroblock_address;
         }
 
@@ -3030,7 +3032,8 @@ gen9_vdenc_mfx_avc_insert_slice_packed_data(VADriverContextP ctx,
         unsigned char *slice_header1 = NULL;
 
         if (slice_index &&
-            IS_KBL(i965->intel.device_info)) {
+            (IS_KBL(i965->intel.device_info) ||
+             IS_GLK(i965->intel.device_info))) {
             slice_header_index = (encode_state->slice_header_index[0] & SLICE_PACKED_DATA_INDEX_MASK);
         }
 
@@ -3894,7 +3897,8 @@ vdenc_hw_interfaces_init(VADriverContextP ctx,
 {
     struct i965_driver_data *i965 = i965_driver_data(ctx);
 
-    if (IS_KBL(i965->intel.device_info)) {
+    if (IS_KBL(i965->intel.device_info) ||
+        IS_GLK(i965->intel.device_info)) {
         gen95_vdenc_hw_interfaces_init(ctx, encoder_context, vdenc_context);
     } else {
         gen9_vdenc_hw_interfaces_init(ctx, encoder_context, vdenc_context);

--- a/src/i965_device_info.c
+++ b/src/i965_device_info.c
@@ -527,10 +527,10 @@ static struct hw_codec_info glk_hw_codec_info = {
 
     .has_mpeg2_decoding = 1,
     .has_h264_decoding = 1,
-    .has_h264_encoding = 0,
+    .has_h264_encoding = 1,
     .has_vc1_decoding = 1,
     .has_jpeg_decoding = 1,
-    .has_jpeg_encoding = 0,
+    .has_jpeg_encoding = 1,
     .has_vpp = 1,
     .has_accelerated_getimage = 1,
     .has_accelerated_putimage = 1,
@@ -538,7 +538,7 @@ static struct hw_codec_info glk_hw_codec_info = {
     .has_di_motion_adptive = 1,
     .has_di_motion_compensated = 1,
     .has_vp8_decoding = 1,
-    .has_vp8_encoding = 0,
+    .has_vp8_encoding = 1,
     .has_h264_mvc_encoding = 0,
     .has_hevc_decoding = 1,
     .has_hevc_encoding = 0,
@@ -546,7 +546,10 @@ static struct hw_codec_info glk_hw_codec_info = {
     .has_hevc10_encoding = 0,
     .has_vp9_decoding = 1,
     .has_vpp_p010 = 1,
-    .has_vp9_encoding = 0,
+    .has_vp9_encoding = 1,
+    .has_lp_h264_encoding = 1,
+
+    .lp_h264_brc_mode = VA_RC_CQP,
 
     .num_filters = 5,
     .filters = {


### PR DESCRIPTION
HEVC encoder will be enabled later.
Fix https://github.com/01org/intel-vaapi-driver/issues/111

Signed-off-by: Zhao Yakui <yakui.zhao@intel.com>
Signed-off-by: Wang, TianTian<tiantian.wang@intel.com>
Signed-off-by: jkyu <jiankang.yu@intel.com>