### PR TITLE
test: check whether MVC encoding is support

### DIFF
--- a/test/i965_avce_test_common.cpp
+++ b/test/i965_avce_test_common.cpp
@@ -65,7 +65,9 @@ VAStatus CheckSupported(VAProfile profile, VAEntrypoint entrypoint)
     case VAProfileH264MultiviewHigh:
     case VAProfileH264StereoHigh:
         if (entrypoint == VAEntrypointEncSlice) {
-            return VA_STATUS_SUCCESS;
+            if (HAS_H264_MVC_ENCODING(i965)) {
+                return VA_STATUS_SUCCESS;
+            }
         }
         break;
 


### PR DESCRIPTION
This fixes https://github.com/01org/intel-vaapi-driver/issues/123

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>