### PR TITLE
correct coding style and silence a gcc warning 

### DIFF
--- a/src/gen9_avc_encoder.c
+++ b/src/gen9_avc_encoder.c
@@ -3155,6 +3155,11 @@ gen9_avc_set_curbe_mbenc(VADriverContextP ctx,
             }
 
         }
+    } else {
+        /* Never get here, just silence a gcc warning */
+        assert(0);
+
+        return;
     }
 
     me_method = (generic_state->frame_type == SLICE_TYPE_B) ? gen9_avc_b_me_method[preset] : gen9_avc_p_me_method[preset];

--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -1155,7 +1155,7 @@ i965_GetConfigAttributes(VADriverContextP ctx,
                      profile == VAProfileH264High) ||
                     profile == VAProfileH264StereoHigh ||
                     profile == VAProfileH264MultiviewHigh ||
-		    profile == VAProfileHEVCMain ||
+                    profile == VAProfileHEVCMain ||
                     profile == VAProfileHEVCMain10) {
                     attrib_list[i].value = VA_ENC_SLICE_STRUCTURE_ARBITRARY_MACROBLOCKS;
                 }

--- a/src/i965_output_dri.c
+++ b/src/i965_output_dri.c
@@ -32,12 +32,9 @@
 
 #define LIBVA_X11_NAME "libva-x11.so.1"
 
-typedef struct dri_drawable *(*dri_get_drawable_func)(
-    VADriverContextP ctx, XID drawable);
-typedef union dri_buffer *(*dri_get_rendering_buffer_func)(
-        VADriverContextP ctx, struct dri_drawable *d);
-typedef void (*dri_swap_buffer_func)(
-    VADriverContextP ctx, struct dri_drawable *d);
+typedef struct dri_drawable *(*dri_get_drawable_func)(VADriverContextP ctx, XID drawable);
+typedef union dri_buffer *(*dri_get_rendering_buffer_func)(VADriverContextP ctx, struct dri_drawable *d);
+typedef void (*dri_swap_buffer_func)(VADriverContextP ctx, struct dri_drawable *d);
 
 struct dri_vtable {
     dri_get_drawable_func               get_drawable;


### PR DESCRIPTION
This fixes https://github.com/01org/intel-vaapi-driver/issues/114