### PR TITLE
VP8 encoder can support VBR method since using the new media kernel

### DIFF
--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -973,7 +973,8 @@ i965_GetConfigAttributes(VADriverContextP ctx,
                     profile != VAProfileMPEG2Simple)
                     attrib_list[i].value |= VA_RC_CBR;
 
-                if (profile == VAProfileVP9Profile0 ||
+                if (profile == VAProfileVP8Version0_3 ||
+                    profile == VAProfileVP9Profile0 ||
                     profile == VAProfileH264ConstrainedBaseline ||
                     profile == VAProfileH264Main ||
                     profile == VAProfileH264High ||


### PR DESCRIPTION
This fixes https://github.com/01org/intel-vaapi-driver/issues/164

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>