### PR TITLE
Gen9 H.264 encoders: Fix condition for enabling MB rate control

### DIFF
--- a/src/gen9_avc_encoder.c
+++ b/src/gen9_avc_encoder.c
@@ -424,7 +424,7 @@ gen9_avc_update_misc_parameters(VADriverContextP ctx,
 
     if (generic_state->internal_rate_mode == VA_RC_CBR) {
         generic_state->min_bit_rate = generic_state->max_bit_rate;
-        generic_state->mb_brc_enabled = encoder_context->brc.mb_rate_control[0];
+        generic_state->mb_brc_enabled = encoder_context->brc.mb_rate_control[0] == 1;
 
         if (generic_state->target_bit_rate != generic_state->max_bit_rate) {
             generic_state->target_bit_rate = generic_state->max_bit_rate;
@@ -432,7 +432,7 @@ gen9_avc_update_misc_parameters(VADriverContextP ctx,
         }
     } else if (generic_state->internal_rate_mode == VA_RC_VBR) {
         generic_state->min_bit_rate = generic_state->max_bit_rate * (2 * encoder_context->brc.target_percentage[0] - 100) / 100;
-        generic_state->mb_brc_enabled = encoder_context->brc.mb_rate_control[0];
+        generic_state->mb_brc_enabled = encoder_context->brc.mb_rate_control[0] == 1;
 
         if (generic_state->target_bit_rate != generic_state->max_bit_rate * encoder_context->brc.target_percentage[0] / 100) {
             generic_state->target_bit_rate = generic_state->max_bit_rate * encoder_context->brc.target_percentage[0] / 100;

--- a/src/gen9_vdenc.c
+++ b/src/gen9_vdenc.c
@@ -860,7 +860,7 @@ gen9_vdenc_update_misc_parameters(VADriverContextP ctx,
         vdenc_context->init_vbv_buffer_fullness_in_bit = encoder_context->brc.hrd_initial_buffer_fullness;
 
         vdenc_context->max_bit_rate = ALIGN(encoder_context->brc.bits_per_second[0], 1000) / 1000;
-        vdenc_context->mb_brc_enabled = encoder_context->brc.mb_rate_control[0];
+        vdenc_context->mb_brc_enabled = encoder_context->brc.mb_rate_control[0] == 1;
         vdenc_context->brc_need_reset = (vdenc_context->brc_initted && encoder_context->brc.need_reset);
 
         if (vdenc_context->internal_rate_mode == I965_BRC_CBR) {


### PR DESCRIPTION
Simplest possible change to fix #166 .  Tested on Skylake with the normal encoder.