### PR TITLE
Fix AUD insert issue in AVC encoder with GEN6/7.5/8.

### DIFF
--- a/src/gen6_mfc.c
+++ b/src/gen6_mfc.c
@@ -823,7 +823,7 @@ gen6_mfc_avc_pipeline_slice_programing(VADriverContextP ctx,
 
     intel_avc_slice_insert_packed_data(ctx, encode_state, encoder_context, slice_index, slice_batch);
 
-    dri_bo_map(vme_context->vme_output.bo , 1);
+    dri_bo_map(vme_context->vme_output.bo, 1);
     msg = (unsigned int *)vme_context->vme_output.bo->virtual;
 
     if (is_intra) {
@@ -1213,8 +1213,10 @@ gen6_mfc_avc_batchbuffer_slice(VADriverContextP ctx,
                              qp_slice,
                              slice_batch);
 
-    if (slice_index == 0)
+    if (slice_index == 0) {
+        intel_avc_insert_aud_packed_data(ctx, encode_state, encoder_context, slice_batch);
         intel_mfc_avc_pipeline_header_programing(ctx, encode_state, encoder_context, slice_batch);
+    }
 
     intel_avc_slice_insert_packed_data(ctx, encode_state, encoder_context, slice_index, slice_batch);
 
@@ -1404,7 +1406,6 @@ gen6_mfc_pipeline(VADriverContextP ctx,
         vaStatus = gen6_mfc_avc_encode_picture(ctx, encode_state, encoder_context);
         break;
 
-        /* FIXME: add for other profile */
     default:
         vaStatus = VA_STATUS_ERROR_UNSUPPORTED_PROFILE;
         break;

--- a/src/gen6_mfc.h
+++ b/src/gen6_mfc.h
@@ -376,6 +376,12 @@ extern
 Bool gen8_mfc_context_init(VADriverContextP ctx, struct intel_encoder_context *encoder_context);
 
 extern void
+intel_avc_insert_aud_packed_data(VADriverContextP ctx,
+                                 struct encode_state *encode_state,
+                                 struct intel_encoder_context *encoder_context,
+                                 struct intel_batchbuffer *batch);
+
+extern void
 intel_avc_slice_insert_packed_data(VADriverContextP ctx,
                                    struct encode_state *encode_state,
                                    struct intel_encoder_context *encoder_context,

--- a/src/gen75_mfc.c
+++ b/src/gen75_mfc.c
@@ -1194,12 +1194,14 @@ gen75_mfc_avc_pipeline_slice_programing(VADriverContextP ctx,
                               encode_state, encoder_context,
                               (rate_control_mode != VA_RC_CQP), qp_slice, slice_batch);
 
-    if (slice_index == 0)
+    if (slice_index == 0) {
+        intel_avc_insert_aud_packed_data(ctx, encode_state, encoder_context, slice_batch);
         intel_mfc_avc_pipeline_header_programing(ctx, encode_state, encoder_context, slice_batch);
+    }
 
     intel_avc_slice_insert_packed_data(ctx, encode_state, encoder_context, slice_index, slice_batch);
 
-    dri_bo_map(vme_context->vme_output.bo , 1);
+    dri_bo_map(vme_context->vme_output.bo, 1);
     msg_ptr = (unsigned char *)vme_context->vme_output.bo->virtual;
 
     if (is_intra) {
@@ -1442,7 +1444,7 @@ gen75_mfc_avc_batchbuffer_slice_command(VADriverContextP ctx,
     int mb_x, mb_y;
     int last_mb, slice_end_x, slice_end_y;
     int remaining_mb = total_mbs;
-    uint32_t fwd_ref , bwd_ref, mb_flag;
+    uint32_t fwd_ref, bwd_ref, mb_flag;
 
     last_mb = slice_param->macroblock_address + total_mbs - 1;
     slice_end_x = last_mb % width_in_mbs;
@@ -1544,8 +1546,10 @@ gen75_mfc_avc_batchbuffer_slice(VADriverContextP ctx,
                               qp_slice,
                               slice_batch);
 
-    if (slice_index == 0)
+    if (slice_index == 0) {
+        intel_avc_insert_aud_packed_data(ctx, encode_state, encoder_context, slice_batch);
         intel_mfc_avc_pipeline_header_programing(ctx, encode_state, encoder_context, slice_batch);
+    }
 
     intel_avc_slice_insert_packed_data(ctx, encode_state, encoder_context, slice_index, slice_batch);
 
@@ -2143,7 +2147,7 @@ gen75_mfc_mpeg2_pipeline_slice_group(VADriverContextP ctx,
     v_start_pos = slice_param->macroblock_address / width_in_mbs;
     assert(h_start_pos + slice_param->num_macroblocks <= width_in_mbs);
 
-    dri_bo_map(vme_context->vme_output.bo , 0);
+    dri_bo_map(vme_context->vme_output.bo, 0);
     msg_ptr = (unsigned char *)vme_context->vme_output.bo->virtual;
 
     if (next_slice_group_param) {
@@ -2527,7 +2531,6 @@ static VAStatus gen75_mfc_pipeline(VADriverContextP ctx,
         vaStatus = gen75_mfc_avc_encode_picture(ctx, encode_state, encoder_context);
         break;
 
-        /* FIXME: add for other profile */
     case VAProfileMPEG2Simple:
     case VAProfileMPEG2Main:
         vaStatus = gen75_mfc_mpeg2_encode_picture(ctx, encode_state, encoder_context);

--- a/src/gen8_mfc.c
+++ b/src/gen8_mfc.c
@@ -1190,12 +1190,14 @@ gen8_mfc_avc_pipeline_slice_programing(VADriverContextP ctx,
                              encode_state, encoder_context,
                              (rate_control_mode != VA_RC_CQP), qp_slice, slice_batch);
 
-    if (slice_index == 0)
+    if (slice_index == 0) {
+        intel_avc_insert_aud_packed_data(ctx, encode_state, encoder_context, slice_batch);
         intel_mfc_avc_pipeline_header_programing(ctx, encode_state, encoder_context, slice_batch);
+    }
 
     intel_avc_slice_insert_packed_data(ctx, encode_state, encoder_context, slice_index, slice_batch);
 
-    dri_bo_map(vme_context->vme_output.bo , 1);
+    dri_bo_map(vme_context->vme_output.bo, 1);
     msg_ptr = (unsigned char *)vme_context->vme_output.bo->virtual;
 
     if (is_intra) {
@@ -1430,7 +1432,7 @@ gen8_mfc_avc_batchbuffer_slice_command(VADriverContextP ctx,
     int mb_x, mb_y;
     int last_mb, slice_end_x, slice_end_y;
     int remaining_mb = total_mbs;
-    uint32_t fwd_ref , bwd_ref, mb_flag;
+    uint32_t fwd_ref, bwd_ref, mb_flag;
     char tmp_qp;
     int number_roi_mbs, max_mb_cmds, i;
 
@@ -1550,8 +1552,10 @@ gen8_mfc_avc_batchbuffer_slice(VADriverContextP ctx,
                              qp_slice,
                              slice_batch);
 
-    if (slice_index == 0)
+    if (slice_index == 0) {
+        intel_avc_insert_aud_packed_data(ctx, encode_state, encoder_context, slice_batch);
         intel_mfc_avc_pipeline_header_programing(ctx, encode_state, encoder_context, slice_batch);
+    }
 
     intel_avc_slice_insert_packed_data(ctx, encode_state, encoder_context, slice_index, slice_batch);
 
@@ -2168,7 +2172,7 @@ gen8_mfc_mpeg2_pipeline_slice_group(VADriverContextP ctx,
     v_start_pos = slice_param->macroblock_address / width_in_mbs;
     assert(h_start_pos + slice_param->num_macroblocks <= width_in_mbs);
 
-    dri_bo_map(vme_context->vme_output.bo , 0);
+    dri_bo_map(vme_context->vme_output.bo, 0);
     msg_ptr = (unsigned char *)vme_context->vme_output.bo->virtual;
 
     if (next_slice_group_param) {
@@ -4264,7 +4268,7 @@ gen8_mfc_vp8_pak_pipeline(VADriverContextP ctx,
 
     is_intra_frame = !pic_param->pic_flags.bits.frame_type;
 
-    dri_bo_map(vme_context->vme_output.bo , 1);
+    dri_bo_map(vme_context->vme_output.bo, 1);
     msg_ptr = (unsigned char *)vme_context->vme_output.bo->virtual;
 
     for (i = 0; i < width_in_mbs * height_in_mbs; i++) {
@@ -4529,7 +4533,6 @@ static VAStatus gen8_mfc_pipeline(VADriverContextP ctx,
         vaStatus = gen8_mfc_avc_encode_picture(ctx, encode_state, encoder_context);
         break;
 
-        /* FIXME: add for other profile */
     case VAProfileMPEG2Simple:
     case VAProfileMPEG2Main:
         vaStatus = gen8_mfc_mpeg2_encode_picture(ctx, encode_state, encoder_context);


### PR DESCRIPTION
If find the AUD NAL in raw data list, it will insert AUD first in
the bitstream.

Fix #155

Signed-off-by: Jun Zhao <jun.zhao@intel.com>