### PR TITLE
gen9_avc_encoder: brc_curbe_size is not static anymore

### DIFF
--- a/src/gen9_avc_encoder.c
+++ b/src/gen9_avc_encoder.c
@@ -4974,7 +4974,7 @@ gen9_avc_kernel_init_brc(VADriverContextP ctx,
     struct i965_kernel common_kernel;
     int i = 0;
 
-    static const int brc_curbe_size[NUM_GEN9_AVC_KERNEL_BRC] = {
+    const int brc_curbe_size[NUM_GEN9_AVC_KERNEL_BRC] = {
         (sizeof(gen9_avc_brc_init_reset_curbe_data)),
         (sizeof(gen9_avc_frame_brc_update_curbe_data)),
         (sizeof(gen9_avc_brc_init_reset_curbe_data)),


### PR DESCRIPTION
Static memory allocation in general is the allocation of memory at compile
time before the associated program is executed.

And this is the case when compiling with clang: it tries to optimize the
allocation of static memory in compilation time, thus commit f896ca2a breaks
the compilation, since the structure can only be defined at execution time.

Fix #184

Signed-off-by: Víctor Manuel Jáquez Leal <vjaquez@igalia.com>