### PR TITLE
Use ASSERT_RET() instead of assert() for some assertions

### DIFF
--- a/src/i965_output_dri.c
+++ b/src/i965_output_dri.c
@@ -147,15 +147,15 @@ i965_put_surface_dri(
     _i965LockMutex(&i965->render_mutex);
 
     dri_drawable = dri_vtable->get_drawable(ctx, (Drawable)draw);
-    assert(dri_drawable);
+    ASSERT_RET(dri_drawable, VA_STATUS_ERROR_ALLOCATION_FAILED);
 
     buffer = dri_vtable->get_rendering_buffer(ctx, dri_drawable);
-    assert(buffer);
+    ASSERT_RET(buffer, VA_STATUS_ERROR_ALLOCATION_FAILED);
 
     dest_region = render_state->draw_region;
     if (dest_region == NULL) {
         dest_region = (struct intel_region *)calloc(1, sizeof(*dest_region));
-        assert(dest_region);
+        ASSERT_RET(dest_region, VA_STATUS_ERROR_ALLOCATION_FAILED);
         render_state->draw_region = dest_region;
     }
 
@@ -172,10 +172,10 @@ i965_put_surface_dri(
         dest_region->pitch = buffer->dri2.pitch;
 
         dest_region->bo = intel_bo_gem_create_from_name(i965->intel.bufmgr, "rendering buffer", buffer->dri2.name);
-        assert(dest_region->bo);
+        ASSERT_RET(dest_region->bo, VA_STATUS_ERROR_UNKNOWN);
 
         ret = dri_bo_get_tiling(dest_region->bo, &(dest_region->tiling), &(dest_region->swizzle));
-        assert(ret == 0);
+        ASSERT_RET((ret == 0), VA_STATUS_ERROR_UNKNOWN);
     }
 
     dest_region->x = dri_drawable->x;

--- a/src/intel_driver.c
+++ b/src/intel_driver.c
@@ -106,10 +106,11 @@ intel_driver_init(VADriverContextP ctx)
     if (g_intel_debug_option_flags)
         fprintf(stderr, "g_intel_debug_option_flags:%x\n", g_intel_debug_option_flags);
 
-    assert(drm_state);
-    assert(VA_CHECK_DRM_AUTH_TYPE(ctx, VA_DRM_AUTH_DRI1) ||
-           VA_CHECK_DRM_AUTH_TYPE(ctx, VA_DRM_AUTH_DRI2) ||
-           VA_CHECK_DRM_AUTH_TYPE(ctx, VA_DRM_AUTH_CUSTOM));
+    ASSERT_RET(drm_state, false);
+    ASSERT_RET((VA_CHECK_DRM_AUTH_TYPE(ctx, VA_DRM_AUTH_DRI1) ||
+                VA_CHECK_DRM_AUTH_TYPE(ctx, VA_DRM_AUTH_DRI2) ||
+                VA_CHECK_DRM_AUTH_TYPE(ctx, VA_DRM_AUTH_CUSTOM)),
+               false);
 
     intel->fd = drm_state->fd;
     intel->dri2Enabled = (VA_CHECK_DRM_AUTH_TYPE(ctx, VA_DRM_AUTH_DRI2) ||


### PR DESCRIPTION
This avoids assertion fault, and the caller can handle the error
properly when the driver returns false or error.

This avoids the assertion fault in
https://github.com/01org/intel-vaapi-driver/issues/186, it also avoids
the assertion fault after https://github.com/01org/libva/issues/51 is fixed
in libva.

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>