### PR TITLE
decode: release huffman_table from decode state

### DIFF
--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -2313,6 +2313,7 @@ i965_destroy_context(struct object_heap *heap, struct object_base *obj)
 
         i965_release_buffer_store(&obj_context->codec_state.decode.pic_param);
         i965_release_buffer_store(&obj_context->codec_state.decode.iq_matrix);
+        i965_release_buffer_store(&obj_context->codec_state.decode.huffman_table);
         i965_release_buffer_store(&obj_context->codec_state.decode.bit_plane);
 
         for (i = 0; i < obj_context->codec_state.decode.num_slice_params; i++)


### PR DESCRIPTION
In i965_destroy_context, ensure we release the huffman_table
buffer_store from the decode state to avoid memory leak.

Fixes #190

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>