### PR TITLE
Add gen9_hevc_enc_kernels.h to the corresponding list

### DIFF
--- a/src/Makefile.sources
+++ b/src/Makefile.sources
@@ -129,6 +129,7 @@ source_h = \
 	i965_avc_encoder_common.h \
 	gen9_hevc_enc_const_def.h \
 	gen9_hevc_enc_kernels.h \
+	gen9_hevc_enc_kernels_binary.h \
 	gen9_hevc_enc_utils.h \
 	gen9_hevc_encoder.h \
 	$(NULL)


### PR DESCRIPTION
Otherwise the package created by 'make dist' doesn't include the
missing file, which will break the build

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>