### PR TITLE
wayland: Also support wl_drm version 1

### DIFF
--- a/src/i965_output_wayland.c
+++ b/src/i965_output_wayland.c
@@ -144,7 +144,8 @@ registry_handle_global(
 
     if (strcmp(interface, "wl_drm") == 0) {
         wl_output->wl_drm = registry_bind(wl_vtable, wl_output->wl_registry,
-                                          id, wl_vtable->drm_interface, 2);
+                                          id, wl_vtable->drm_interface,
+                                          (version < 2) ? version : 2);
     }
 }
 


### PR DESCRIPTION
Just using version 2 without checking would lead to a protocol error
bringing down the entire application, and wl_drm version 1 is still
supported since v2 only adds PRIME capabilities.

This is the same as 01org/libva#66 for intel-vaapi-driver