### PR TITLE
enc: Add restriction to vp9 encoder frame rate to avoid hang

### DIFF
--- a/src/gen9_vp9_encoder.c
+++ b/src/gen9_vp9_encoder.c
@@ -46,6 +46,7 @@
 #include "vp9_probs.h"
 #include "gen9_vp9_const_def.h"
 
+#define MAX_VP9_ENCODER_FRAMERATE       60
 #define MAX_VP9_ENCODER_SURFACES        64
 
 #define MAX_URB_SIZE                    4096 /* In register */
@@ -3723,6 +3724,11 @@ gen9_encode_vp9_check_parameter(VADriverContextP ctx,
 
             vp9_state->gop_size = encoder_context->brc.gop_size;
             vp9_state->framerate = encoder_context->brc.framerate[0];
+            if ((vp9_state->framerate.num / vp9_state->framerate.den) > MAX_VP9_ENCODER_FRAMERATE) {
+                vp9_state->framerate.num = MAX_VP9_ENCODER_FRAMERATE * vp9_state->framerate.den;
+                i965_log_info(ctx, "gen9_encode_vp9_check_parameter: Too high frame rate(num: %d, den: %d), max supported is %d fps.\n",
+                              vp9_state->framerate.num, vp9_state->framerate.den, MAX_VP9_ENCODER_FRAMERATE);
+            }
 
             if (encoder_context->rate_control_mode == VA_RC_CBR ||
                 !encoder_context->brc.target_percentage[0]) {


### PR DESCRIPTION
Temporarily limit the maximum frame rate for vp9 encoder to avoid gpu hang 
Signed-off-by: jkyu <jiankang.yu@intel.com>