### PR TITLE
Copying line intel_h264_enc_roi_config from gen75_vmc.c to gen7_vmc.c

### DIFF
--- a/src/gen7_vme.c
+++ b/src/gen7_vme.c
@@ -752,6 +752,7 @@ static VAStatus gen7_vme_prepare(VADriverContextP ctx,
 
     intel_vme_update_mbmv_cost(ctx, encode_state, encoder_context);
     intel_h264_initialize_mbmv_cost(ctx, encode_state, encoder_context);
+    intel_h264_enc_roi_config(ctx, encode_state, encoder_context);
 
     /*Setup all the memory object*/
     gen7_vme_surface_setup(ctx, encode_state, is_intra, encoder_context);

--- a/src/gen7_vme.c
+++ b/src/gen7_vme.c
@@ -752,7 +752,6 @@ static VAStatus gen7_vme_prepare(VADriverContextP ctx,
 
     intel_vme_update_mbmv_cost(ctx, encode_state, encoder_context);
     intel_h264_initialize_mbmv_cost(ctx, encode_state, encoder_context);
-    intel_h264_enc_roi_config(ctx, encode_state, encoder_context);
 
     /*Setup all the memory object*/
     gen7_vme_surface_setup(ctx, encode_state, is_intra, encoder_context);


### PR DESCRIPTION
VAEncROI started to work on a GEN7 chip after this change.

Please review it and double check if copy this line is a sane think to do. I didn't
have studied the whole driver to understand the whole thing.
