### PR TITLE
Fixes #236: add explicit braces to avoid 'ambiguous else' warning.

### DIFF
--- a/test/i965_config_test.cpp
+++ b/test/i965_config_test.cpp
@@ -58,6 +58,7 @@ TEST_P(I965ConfigTest, Create)
 
     EXPECT_STATUS_EQ(expect, actual);
 
-    if (actual != VA_STATUS_SUCCESS)
+    if (actual != VA_STATUS_SUCCESS) {
         EXPECT_INVALID_ID(config);
+    }
 }

--- a/test/i965_test_environment.cpp
+++ b/test/i965_test_environment.cpp
@@ -82,8 +82,9 @@ void I965TestEnvironment::SetUp()
 
 void I965TestEnvironment::TearDown()
 {
-    if (m_vaDisplay)
+    if (m_vaDisplay) {
         EXPECT_STATUS(vaTerminate(m_vaDisplay));
+    }
 
     if (m_handle >= 0)
         close(m_handle);

--- a/test/i965_test_fixture.cpp
+++ b/test/i965_test_fixture.cpp
@@ -44,12 +44,13 @@ Surfaces I965TestFixture::createSurfaces(int w, int h, int format, size_t count,
     } else {
         VADriverContextP ctx(*this);
         EXPECT_PTR(ctx);
-        if (ctx)
+        if (ctx) {
             EXPECT_STATUS(
                 ctx->vtable->vaCreateSurfaces2(
                     *this, format, w, h, surfaces.data(), surfaces.size(),
                     const_cast<VASurfaceAttrib*>(attributes.data()),
                     attributes.size()));
+	}
     }
 
     for (size_t i(0); i < count; ++i) {


### PR DESCRIPTION
Signed-off-by: Kelly Ledford <kelly.ledford@intel.com>