### PR TITLE
Fix deprecated warning

### DIFF
--- a/src/i965_decoder_utils.c
+++ b/src/i965_decoder_utils.c
@@ -962,12 +962,9 @@ intel_decoder_check_avc_parameter(VADriverContextP ctx,
     ASSERT_RET((pic_param->CurrPic.picture_id != VA_INVALID_SURFACE), VA_STATUS_ERROR_INVALID_PARAMETER);
     ASSERT_RET((pic_param->CurrPic.picture_id == decode_state->current_render_target), VA_STATUS_ERROR_INVALID_PARAMETER);
 
-    if ((h264_profile != VAProfileH264Baseline)) {
-        if (pic_param->num_slice_groups_minus1 ||
-            pic_param->pic_fields.bits.redundant_pic_cnt_present_flag) {
-            WARN_ONCE("Unsupported the FMO/ASO constraints!!!\n");
-            goto error;
-        }
+    if (pic_param->pic_fields.bits.redundant_pic_cnt_present_flag) {
+        WARN_ONCE("Unsupported the ASO constraints!!!\n");
+        goto error;
     }
 
     /* Fill in the reference objects array with the actual VA surface

--- a/src/i965_drv_video.h
+++ b/src/i965_drv_video.h
@@ -40,6 +40,8 @@
 #include <va/va_backend.h>
 #include <va/va_backend_vpp.h>
 
+#include "va_backend_compat.h"
+
 #include "i965_mutext.h"
 #include "object_heap.h"
 #include "intel_driver.h"

--- a/src/va_backend_compat.h
+++ b/src/va_backend_compat.h
@@ -58,4 +58,12 @@
 
 #endif
 
+#if VA_CHECK_VERSION(1,0,0)
+
+# define VAEncPackedHeaderMiscMask      0x80000000
+# define VAEncPackedHeaderH264_SEI      (VAEncPackedHeaderMiscMask | 1)
+# define VAEncPackedHeaderHEVC_SEI      (VAEncPackedHeaderMiscMask | 1)
+
+#endif
+
 #endif /* VA_BACKEND_COMPAT_H */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -102,7 +102,6 @@ test_i965_drv_video_CPPFLAGS =						\
 
 test_i965_drv_video_CXXFLAGS =						\
 	-Wall -Werror							\
-	-Wno-deprecated-declarations					\
 	$(AM_CXXFLAGS)							\
 	$(NULL)
 

--- a/test/i965_avcd_config_test.cpp
+++ b/test/i965_avcd_config_test.cpp
@@ -96,8 +96,6 @@ VAStatus HasMVCDecodeSupport()
 }
 
 static const std::vector<ConfigTestInput> inputs = {
-    { VAProfileH264Baseline, VAEntrypointVLD, &ProfileNotSupported },
-
     { VAProfileH264ConstrainedBaseline, VAEntrypointVLD, &HasDecodeSupport },
     { VAProfileH264Main, VAEntrypointVLD, &HasDecodeSupport },
     { VAProfileH264High, VAEntrypointVLD, &HasDecodeSupport },

--- a/test/i965_avce_config_test.cpp
+++ b/test/i965_avce_config_test.cpp
@@ -129,10 +129,6 @@ VAStatus HasMVCEncodeSupport()
 }
 
 static const std::vector<ConfigTestInput> inputs = {
-    {VAProfileH264Baseline, VAEntrypointEncSlice, &ProfileNotSupported},
-    {VAProfileH264Baseline, VAEntrypointEncSliceLP, &ProfileNotSupported},
-    {VAProfileH264Baseline, VAEntrypointEncPicture, &ProfileNotSupported},
-
     {VAProfileH264ConstrainedBaseline, VAEntrypointEncSlice, &HasEncodeSupport},
     {VAProfileH264ConstrainedBaseline, VAEntrypointEncSliceLP, &HasLPEncodeSupport},
     {VAProfileH264ConstrainedBaseline, VAEntrypointEncPicture, &H264NotSupported},

--- a/test/i965_avce_test_common.cpp
+++ b/test/i965_avce_test_common.cpp
@@ -42,9 +42,6 @@ VAStatus CheckSupported(VAProfile profile, VAEntrypoint entrypoint)
     EXPECT_PTR(i965);
 
     switch(profile) {
-    case VAProfileH264Baseline:
-        return VA_STATUS_ERROR_UNSUPPORTED_PROFILE;
-
     case VAProfileH264ConstrainedBaseline:
     case VAProfileH264Main:
     case VAProfileH264High:

--- a/test/i965_streamable.h
+++ b/test/i965_streamable.h
@@ -432,8 +432,6 @@ operator<<(std::ostream& os, const VAProfile& profile)
         return os << "VAProfileVP9Profile2";
     case VAProfileVP9Profile3:
         return os << "VAProfileVP9Profile3";
-    case VAProfileH264Baseline:
-        return os << "VAProfileH264Baseline";
     case VAProfileH264ConstrainedBaseline:
         return os << "VAProfileH264ConstrainedBaseline";
     case VAProfileH264High:


### PR DESCRIPTION
enums and VA features marked as deprecated should not be used any more.

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>