### PR TITLE
Fix Seeking with VC1 after 6702b01ee3598017f05374bfc7956493f790361c

### DIFF
--- a/src/gen6_mfd.c
+++ b/src/gen6_mfd.c
@@ -1619,10 +1619,11 @@ gen6_mfd_vc1_pred_pipe_state(VADriverContextP ctx,
     if (gen6_mfd_context->reference_surface[0].surface_id != VA_INVALID_ID) {
         if (picture_type == 1 || picture_type == 2) { /* P/B picture */
             struct gen6_vc1_surface *gen6_vc1_surface = gen6_mfd_context->reference_surface[0].obj_surface->private_data;
-
-            intensitycomp_single_fwd = gen6_vc1_surface->intensity_compensation;
-            luma_scale1 = gen6_vc1_surface->luma_scale;
-            luma_shift1 = gen6_vc1_surface->luma_shift;
+            if (gen6_vc1_surface) {
+                intensitycomp_single_fwd = gen6_vc1_surface->intensity_compensation;
+                luma_scale1 = gen6_vc1_surface->luma_scale;
+                luma_shift1 = gen6_vc1_surface->luma_shift;
+            }
         }
     }
 

--- a/src/gen7_mfd.c
+++ b/src/gen7_mfd.c
@@ -1681,10 +1681,11 @@ gen7_mfd_vc1_pred_pipe_state(VADriverContextP ctx,
     if (gen7_mfd_context->reference_surface[0].surface_id != VA_INVALID_ID) {
         if (picture_type == 1 || picture_type == 2) { /* P/B picture */
             struct gen7_vc1_surface *gen7_vc1_surface = gen7_mfd_context->reference_surface[0].obj_surface->private_data;
-
-            intensitycomp_single_fwd = gen7_vc1_surface->intensity_compensation;
-            luma_scale1 = gen7_vc1_surface->luma_scale;
-            luma_shift1 = gen7_vc1_surface->luma_shift;
+            if (gen7_vc1_surface) {
+                intensitycomp_single_fwd = gen7_vc1_surface->intensity_compensation;
+                luma_scale1 = gen7_vc1_surface->luma_scale;
+                luma_shift1 = gen7_vc1_surface->luma_shift;
+            }
         }
     }
 

--- a/src/gen8_mfd.c
+++ b/src/gen8_mfd.c
@@ -1725,10 +1725,11 @@ gen8_mfd_vc1_pred_pipe_state(VADriverContextP ctx,
     if (gen7_mfd_context->reference_surface[0].surface_id != VA_INVALID_ID) {
         if (picture_type == 1 || picture_type == 2) { /* P/B picture */
             struct gen7_vc1_surface *gen7_vc1_surface = gen7_mfd_context->reference_surface[0].obj_surface->private_data;
-
-            intensitycomp_single_fwd = gen7_vc1_surface->intensity_compensation;
-            luma_scale1 = gen7_vc1_surface->luma_scale;
-            luma_shift1 = gen7_vc1_surface->luma_shift;
+            if (gen7_vc1_surface) {
+                intensitycomp_single_fwd = gen7_vc1_surface->intensity_compensation;
+                luma_scale1 = gen7_vc1_surface->luma_scale;
+                luma_shift1 = gen7_vc1_surface->luma_shift;
+            }
         }
     }
 


### PR DESCRIPTION
We found some issues with kodi when seeking through VC-1 files after above commit was merged. It seems the priv_data is not checked for being null.

You can reproduce the issue when pausing / resuming VC-1 files. The gen8_mfd change was tested working.

Debuglog with backtrace: http://sprunge.us/PPWX
Sample to reproduce: http://milhouse.libreelec.tv/other/MKV9_vc-1_6ch_ac3_dts_pcm.mkv