### PR TITLE
Do not create sei unit

### DIFF
--- a/src/gen6_mfc_common.c
+++ b/src/gen6_mfc_common.c
@@ -644,31 +644,6 @@ void intel_mfc_avc_pipeline_header_programing(VADriverContextP ctx,
                                    0,
                                    !param->has_emulation_bytes,
                                    slice_batch);
-    } else if (rate_control_mode == VA_RC_CBR) {
-        // this is frist AU
-        struct gen6_mfc_context *mfc_context = encoder_context->mfc_context;
-
-        unsigned char *sei_data = NULL;
-
-        int length_in_bits = build_avc_sei_buffer_timing(
-                                 mfc_context->vui_hrd.i_initial_cpb_removal_delay_length,
-                                 mfc_context->vui_hrd.i_initial_cpb_removal_delay,
-                                 0,
-                                 mfc_context->vui_hrd.i_cpb_removal_delay_length,                                                       mfc_context->vui_hrd.i_cpb_removal_delay * mfc_context->vui_hrd.i_frame_number,
-                                 mfc_context->vui_hrd.i_dpb_output_delay_length,
-                                 0,
-                                 &sei_data);
-        mfc_context->insert_object(ctx,
-                                   encoder_context,
-                                   (unsigned int *)sei_data,
-                                   ALIGN(length_in_bits, 32) >> 5,
-                                   length_in_bits & 0x1f,
-                                   5,
-                                   0,
-                                   0,
-                                   1,
-                                   slice_batch);
-        free(sei_data);
     }
 }
 


### PR DESCRIPTION
Instead the application should provide a right packed SEI buffer if
SEI is required because it is hard to know the value for each SEI
element in the driver.

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>