### PR TITLE
test/streamables: use new vaStr methods when appropriate

### DIFF
--- a/test/i965_streamable.h
+++ b/test/i965_streamable.h
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <valarray>
 #include <va/va.h>
+#include <va/va_str.h>
 
 namespace std {
     template <typename T, const size_t S> inline std::ostream&
@@ -395,85 +396,13 @@ operator<<(std::ostream& os, const VAImage& image)
 inline std::ostream&
 operator<<(std::ostream& os, const VAProfile& profile)
 {
-    switch(profile) {
-    case VAProfileNone:
-        return os << "VAProfileNone";
-    case VAProfileMPEG2Simple:
-        return os << "VAProfileMPEG2Simple";
-    case VAProfileMPEG2Main:
-        return os << "VAProfileMPEG2Main";
-    case VAProfileMPEG4Simple:
-        return os << "VAProfileMPEG4Simple";
-    case VAProfileMPEG4AdvancedSimple:
-        return os << "VAProfileMPEG4AdvancedSimple";
-    case VAProfileMPEG4Main:
-        return os << "VAProfileMPEG4Main";
-    case VAProfileVC1Simple:
-        return os << "VAProfileVC1Simple";
-    case VAProfileVC1Main:
-        return os << "VAProfileVC1Main";
-    case VAProfileVC1Advanced:
-        return os << "VAProfileVC1Advanced";
-    case VAProfileH263Baseline:
-        return os << "VAProfileH263Baseline";
-    case VAProfileJPEGBaseline:
-        return os << "VAProfileJPEGBaseline";
-    case VAProfileVP8Version0_3:
-        return os << "VAProfileVP8Version0_3";
-    case VAProfileHEVCMain:
-        return os << "VAProfileHEVCMain";
-    case VAProfileHEVCMain10:
-        return os << "VAProfileHEVCMain10";
-    case VAProfileVP9Profile0:
-        return os << "VAProfileVP9Profile0";
-    case VAProfileVP9Profile1:
-        return os << "VAProfileVP9Profile1";
-    case VAProfileVP9Profile2:
-        return os << "VAProfileVP9Profile2";
-    case VAProfileVP9Profile3:
-        return os << "VAProfileVP9Profile3";
-    case VAProfileH264ConstrainedBaseline:
-        return os << "VAProfileH264ConstrainedBaseline";
-    case VAProfileH264High:
-        return os << "VAProfileH264High";
-    case VAProfileH264Main:
-        return os << "VAProfileH264Main";
-    case VAProfileH264MultiviewHigh:
-        return os << "VAProfileH264MultiviewHigh";
-    case VAProfileH264StereoHigh:
-        return os << "VAProfileH264StereoHigh";
-    default:
-        return os << "Unknown VAProfile: " << static_cast<int>(profile);
-    }
+    return os << vaProfileStr(profile);
 }
 
 inline std::ostream&
 operator<<(std::ostream& os, const VAEntrypoint& entrypoint)
 {
-    switch(entrypoint) {
-    case VAEntrypointVLD:
-        return os << "VAEntrypointVLD";
-    case VAEntrypointIZZ:
-        return os << "VAEntrypointIZZ";
-    case VAEntrypointIDCT:
-        return os << "VAEntrypointIDCT";
-    case VAEntrypointMoComp:
-        return os << "VAEntrypointMoComp";
-    case VAEntrypointDeblocking:
-        return os << "VAEntrypointDeblocking";
-    case VAEntrypointVideoProc:
-        return os << "VAEntrypointVideoProc";
-    case VAEntrypointEncSlice:
-        return os << "VAEntrypointEncSlice";
-    case VAEntrypointEncSliceLP:
-        return os << "VAEntrypointEncSliceLP";
-    case VAEntrypointEncPicture:
-        return os << "VAEntrypointEncPicture";
-    case VAEntrypointFEI:
-        return os << "VAEntrypointFEI";
-    default:
-        return os << "Unknown VAEntrypoint: " << static_cast<int>(entrypoint);
-    }
+    return os << vaEntrypointStr(entrypoint);
 }
 
 #endif // I965_STREAMABLE_H


### PR DESCRIPTION
New vaStr methods were added in libva 2.0.

Fixes #273

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>