### PR TITLE
Add upper bound check in HCP_IND_OBJ_BASE_ADDR_STATE

### DIFF
--- a/src/gen9_mfd.c
+++ b/src/gen9_mfd.c
@@ -341,7 +341,7 @@ gen9_hcpd_ind_obj_base_addr_state(VADriverContextP ctx,
 
     OUT_BCS_BATCH(batch, HCP_IND_OBJ_BASE_ADDR_STATE | (14 - 2));
     OUT_BUFFER_MA_REFERENCE(slice_data_bo);        /* DW 1..3 */
-    OUT_BUFFER_NMA_REFERENCE(NULL);                /* DW 4..5, Upper Bound */
+    OUT_BCS_RELOC64(batch, slice_data_bo, I915_GEM_DOMAIN_RENDER, 0, ALIGN(slice_data_bo->size, 4096));
     OUT_BUFFER_MA_REFERENCE(NULL);                 /* DW 6..8, CU, ignored */
     OUT_BUFFER_MA_TARGET(NULL);                    /* DW 9..11, PAK-BSE, ignored */
     OUT_BUFFER_NMA_TARGET(NULL);                   /* DW 12..13, Upper Bound  */


### PR DESCRIPTION
The commit 29e375a fixed some VP9 decoding artifacts reported in
https://github.com/01org/intel-vaapi-driver/issues/262, but we still
see artifacts when decoding some VP9 clips. More investigations show
that the artifacts are caused by graphics address 0

The graphics address for a GEM BO may be 0 since the commit
below was merged into i915 KMD

commit 2889caa9232109afc8881f29a2205abeb5709d0c
Author: Chris Wilson <chris@chris-wilson.co.uk>
Date:   Fri Jun 16 15:05:19 2017 +0100

    drm/i915: Eliminate lots of iterations over the execobjects array

So we never saw this issue before commit 2889caa

Setting upper bound to 0 causes that HW ignores upper bound check, which
works for non-zero base graphics address in HCP pipeline, however the
upper bound check is required for graphics address 0, so we add the bound
check no matter what is the graphics address

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>