### PR TITLE
configure: set strict default compiler flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,6 +212,9 @@ if test "$enable_wayland" = "yes"; then
 fi
 AM_CONDITIONAL(USE_WAYLAND, test "$USE_WAYLAND" = "yes")
 
+AC_SUBST([AM_CFLAGS], ["-Wall -Werror"])
+AC_SUBST([AM_CXXFLAGS], ["-Wall -Werror"])
+
 AC_OUTPUT([
     Makefile
     src/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,7 +52,7 @@ include Makefile.sources
 
 # convenience library that can be linked by driver and tests
 noinst_LTLIBRARIES		= libi965_drv_video.la
-libi965_drv_video_la_CFLAGS	= $(driver_cflags)
+libi965_drv_video_la_CFLAGS	= $(driver_cflags) $(AM_CFLAGS)
 libi965_drv_video_la_LDFLAGS	= $(driver_ldflags)
 libi965_drv_video_la_LIBADD	= $(driver_libs)
 libi965_drv_video_la_SOURCES	= $(source_c)
@@ -60,7 +60,7 @@ libi965_drv_video_la_SOURCES	= $(source_c)
 # driver module
 i965_drv_video_la_LTLIBRARIES	= i965_drv_video.la
 i965_drv_video_ladir		= $(LIBVA_DRIVERS_PATH)
-i965_drv_video_la_CFLAGS	= $(driver_cflags)
+i965_drv_video_la_CFLAGS	= $(driver_cflags) $(AM_CFLAGS)
 i965_drv_video_la_LDFLAGS	= -module $(driver_ldflags)
 i965_drv_video_la_LIBADD	= libi965_drv_video.la $(driver_libs)
 i965_drv_video_la_SOURCES	=

--- a/src/gen8_mfc.c
+++ b/src/gen8_mfc.c
@@ -3004,8 +3004,8 @@ gen8_mfc_jpeg_huff_table_state(VADriverContextP ctx,
     assert(encode_state->huffman_table && encode_state->huffman_table->buffer);
     huff_buffer = (VAHuffmanTableBufferJPEGBaseline *)encode_state->huffman_table->buffer;
 
-    memset(dc_table, 0, 12);
-    memset(ac_table, 0, 162);
+    memset(dc_table, 0, sizeof(dc_table));
+    memset(ac_table, 0, sizeof(ac_table));
 
     for (index = 0; index < num_tables; index++) {
         int id = va_to_gen7_jpeg_hufftable[index];

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = subdir-objects
 
-AM_CXXFLAGS =								\
+AM_CXXFLAGS +=								\
 	-I$(top_srcdir)/test/gtest/include				\
 	$(NULL)
 
@@ -98,11 +98,6 @@ test_i965_drv_video_CPPFLAGS =						\
 	$(LIBVA_DEPS_CFLAGS)						\
 	$(LIBVA_DRM_DEPS_CFLAGS)					\
 	$(AM_CPPFLAGS)							\
-	$(NULL)
-
-test_i965_drv_video_CXXFLAGS =						\
-	-Wall -Werror							\
-	$(AM_CXXFLAGS)							\
 	$(NULL)
 
 check-local: test_i965_drv_video


### PR DESCRIPTION
Use -Wall -Werror compiler flags for stricter compilation.
Also ensure per-target C/CXXFLAGS include AM_C/CXXFLAGS.

Fixes #301

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>