### PR TITLE
fix memset size for fixed array

### DIFF
--- a/src/gen8_mfc.c
+++ b/src/gen8_mfc.c
@@ -3004,8 +3004,8 @@ gen8_mfc_jpeg_huff_table_state(VADriverContextP ctx,
     assert(encode_state->huffman_table && encode_state->huffman_table->buffer);
     huff_buffer = (VAHuffmanTableBufferJPEGBaseline *)encode_state->huffman_table->buffer;
 
-    memset(dc_table, 0, 12);
-    memset(ac_table, 0, 162);
+    memset(dc_table, 0, sizeof(dc_table));
+    memset(ac_table, 0, sizeof(ac_table));
 
     for (index = 0; index < num_tables; index++) {
         int id = va_to_gen7_jpeg_hufftable[index];


### PR DESCRIPTION
Use sizeof on fixed array instead of hard-coded value.

The hard-coded value did not account for the size of the
data type (uint32_t) and therefore did not zero out the
entire array, rather it only zero'd out number of elements
bytes.

This prevents compiler memset-elt-size error when using
-Wall -Werror compiler flags.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>