### PR TITLE
AVC encoder: fix ROI config for CQP

### DIFF
--- a/src/gen6_mfc_common.c
+++ b/src/gen6_mfc_common.c
@@ -2105,6 +2105,8 @@ intel_h264_enc_roi_config(VADriverContextP ctx,
     if (!vme_context->roi_enabled)
         return;
 
+    num_roi = encoder_context->brc.num_roi;
+
     if ((vme_context->saved_width_mbs !=  width_in_mbs) ||
         (vme_context->saved_height_mbs != height_in_mbs)) {
         free(vme_context->qp_per_mb);


### PR DESCRIPTION
Introduced in:

commit 972e6f2b36499389bc7cb7bb34414423b5525143
Author: Xiang, Haihao <haihao.xiang@intel.com>
Date:   Wed Jan 4 09:40:47 2017 +0800

    AVC encoder: use generic ROI parameters

num_roi setting was lost and thus always 0, which essentially
disabled the "for (j = num_roi; j ; j--)" loop in the
VA_RC_CQP case.

Fix this by ensuring num_roi is set to the correct value stored
in the common structure.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>