### PR TITLE
Misc fixes

### DIFF
--- a/src/gen8_mfc.c
+++ b/src/gen8_mfc.c
@@ -2723,18 +2723,13 @@ static void
 get_reciprocal_dword_qm(unsigned char *raster_qm, uint32_t *dword_qm)
 {
     int i = 0, j = 0;
-    short reciprocal_qm[64];
+    short hdw, ldw;
 
-    for (i = 0; i < 64; i++) {
-        reciprocal_qm[i] = 65535 / (raster_qm[i]);
+    for (i = 0, j = 0; i < 64; i += 2, j++) {
+        hdw = 65535 / (raster_qm[i]);
+        ldw = 65535 / (raster_qm[i + 1]);
+        dword_qm[j] = (hdw << 16) | ldw;
     }
-
-    for (i = 0; i < 64; i++) {
-        dword_qm[j] = ((reciprocal_qm[i + 1] << 16) | (reciprocal_qm[i]));
-        j++;
-        i++;
-    }
-
 }
 
 

--- a/src/gen9_hevc_enc_utils.c
+++ b/src/gen9_hevc_enc_utils.c
@@ -29,10 +29,10 @@
 #include "intel_driver.h"
 #include "gen9_hevc_enc_utils.h"
 
-static int
+static unsigned int
 hevc_get_max_mbps(unsigned int level_idc)
 {
-    int max_bps = 0;
+    unsigned int max_bps = 0;
 
     switch (level_idc) {
     case 30:
@@ -85,7 +85,8 @@ gen9_hevc_get_profile_level_max_frame(VAEncSequenceParameterBufferHEVC *seq_para
                                       unsigned int frame_rate)
 {
     double bits_per_mb, tmp_f;
-    int max_mbps, num_mb_per_frame;
+    int num_mb_per_frame;
+    unsigned int max_mbps;
     unsigned long long max_byte_per_pic, max_byte_per_pic_not0;
     int profile_level_max_frame;
     double frameRateD = 100;

--- a/src/gen9_hevc_encoder.c
+++ b/src/gen9_hevc_encoder.c
@@ -783,7 +783,7 @@ static void
 gen9_hevc_set_gpe_1d_surface(VADriverContextP ctx,
                              struct gen9_hevc_encoder_context *priv_ctx,
                              struct i965_gpe_context *gpe_context,
-                             enum GEN9_HEVC_ENC_SURFACE_TYPE surface_type,
+                             GEN9_HEVC_ENC_SURFACE_TYPE surface_type,
                              int bti_idx,
                              int is_raw_buffer,
                              int size,
@@ -812,7 +812,7 @@ static void
 gen9_hevc_set_gpe_2d_surface(VADriverContextP ctx,
                              struct gen9_hevc_encoder_context *priv_ctx,
                              struct i965_gpe_context *gpe_context,
-                             enum GEN9_HEVC_ENC_SURFACE_TYPE surface_type,
+                             GEN9_HEVC_ENC_SURFACE_TYPE surface_type,
                              int bti_idx,
                              int has_uv_surface,
                              int is_media_block_rw,
@@ -850,7 +850,7 @@ static void
 gen9_hevc_set_gpe_adv_surface(VADriverContextP ctx,
                               struct gen9_hevc_encoder_context *priv_ctx,
                               struct i965_gpe_context *gpe_context,
-                              enum GEN9_HEVC_ENC_SURFACE_TYPE surface_type,
+                              GEN9_HEVC_ENC_SURFACE_TYPE surface_type,
                               int bti_idx,
                               struct object_surface *surface_object)
 {
@@ -864,7 +864,7 @@ gen9_hevc_set_gpe_adv_surface(VADriverContextP ctx,
 
 static void
 gen9_hevc_add_gpe_surface(struct gen9_hevc_encoder_context *priv_ctx,
-                          enum GEN9_HEVC_ENC_SURFACE_TYPE surface_type,
+                          GEN9_HEVC_ENC_SURFACE_TYPE surface_type,
                           struct i965_gpe_resource *gpe_buffer,
                           struct object_surface *surface_object)
 {

--- a/src/gen9_hevc_encoder.c
+++ b/src/gen9_hevc_encoder.c
@@ -1245,7 +1245,7 @@ gen9_hevc_enc_init_parameters(VADriverContextP ctx,
         return VA_STATUS_ERROR_INVALID_PARAMETER;
 
     va_status = gen9_hevc_enc_check_parameters(ctx, encode_state, encoder_context);
-    if (va_status |= VA_STATUS_SUCCESS)
+    if (va_status != VA_STATUS_SUCCESS)
         return va_status;
 
     gen9_hevc_enc_init_seq_parameters(priv_ctx, generic_state, priv_state, seq_param);

--- a/src/gen9_hevc_encoder.c
+++ b/src/gen9_hevc_encoder.c
@@ -4148,7 +4148,7 @@ gen9_hevc_set_control_region(VADriverContextP ctx,
             }
         } else {
             int cur_lcu_pel_y = region_start_table[GEN9_HEVC_ENC_REGION_START_Y_OFFSET +
-                                                   (k * priv_state->num_regions_in_slice)] << 5;
+                                                                                       (k * priv_state->num_regions_in_slice)] << 5;
             int ts_width = (priv_state->picture_width + 16) >> 5;
             int ts_height = height;
             int offset_y = -4 * ((ts_width + 1) >> 1);

--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -2857,8 +2857,7 @@ i965_BufferSetNumElements(VADriverContextP ctx,
         return vaStatus;
     }
 
-    if ((num_elements < 0) ||
-        (num_elements > obj_buffer->max_num_elements)) {
+    if (num_elements > obj_buffer->max_num_elements) {
         vaStatus = VA_STATUS_ERROR_MAX_NUM_EXCEEDED;
     } else {
         obj_buffer->num_elements = num_elements;

--- a/src/i965_encoder_vp8.c
+++ b/src/i965_encoder_vp8.c
@@ -1731,7 +1731,8 @@ i965_encoder_vp8_vme_init_mpu_tpu_buffer(VADriverContextP ctx,
     i965_unmap_gpe_resource(&vp8_context->pak_mpu_tpu_updated_token_probability_buffer);
 }
 
-#define ALLOC_VP8_RESOURCE_BUFFER(buffer, bufsize, des) {       \
+#define ALLOC_VP8_RESOURCE_BUFFER(buffer, bufsize, des)         \
+    do {                                                        \
         vp8_context->buffer.type = I965_GPE_RESOURCE_BUFFER;    \
         vp8_context->buffer.width = (bufsize);                  \
         vp8_context->buffer.height = 1;                         \

--- a/src/i965_encoder_vp8.c
+++ b/src/i965_encoder_vp8.c
@@ -3623,7 +3623,7 @@ i965_encoder_vp8_vme_mbenc_add_surfaces(VADriverContextP ctx,
 
         i965_add_buffer_gpe_surface(ctx,
                                     gpe_context,
-                                    &vp8_context->reference_frame_mb_count_buffer ,
+                                    &vp8_context->reference_frame_mb_count_buffer,
                                     0,
                                     32, /* sizeof(unsigned int) * 8 */
                                     0,


### PR DESCRIPTION
One can build with clang with -Wall -Wno-bitfield-constant-conversion without warnings now.