### PR TITLE
VC1: Fix for frame coding mode

### DIFF
--- a/src/gen75_mfd.c
+++ b/src/gen75_mfd.c
@@ -2080,10 +2080,12 @@ gen75_mfd_vc1_pic_state(VADriverContextP ctx,
     assert(pic_param->picture_fields.bits.frame_coding_mode < 3);
 
     if (pic_param->sequence_fields.bits.interlace) {
-        if (!pic_param->picture_fields.bits.top_field_first)
-            fcm = 3;
-        else
+        if (pic_param->picture_fields.bits.frame_coding_mode < 2)
             fcm = pic_param->picture_fields.bits.frame_coding_mode;
+        else if (!pic_param->picture_fields.bits.top_field_first)
+            fcm = 3; /* Field with bottom field first */
+        else
+            fcm = 2; /* Field with top field first */
     }
 
     if (pic_param->sequence_fields.bits.interlace &&

--- a/src/gen7_mfd.c
+++ b/src/gen7_mfd.c
@@ -1814,10 +1814,12 @@ gen7_mfd_vc1_pic_state(VADriverContextP ctx,
     assert(pic_param->picture_fields.bits.frame_coding_mode < 3);
 
     if (pic_param->sequence_fields.bits.interlace) {
-        if (!pic_param->picture_fields.bits.top_field_first)
-            fcm = 3;
-        else
+        if (pic_param->picture_fields.bits.frame_coding_mode < 2)
             fcm = pic_param->picture_fields.bits.frame_coding_mode;
+        else if (!pic_param->picture_fields.bits.top_field_first)
+            fcm = 3; /* Field with bottom field first */
+        else
+            fcm = 2; /* Field with top field first */
     }
 
     if (pic_param->sequence_fields.bits.interlace &&

--- a/src/gen8_mfd.c
+++ b/src/gen8_mfd.c
@@ -1859,10 +1859,12 @@ gen8_mfd_vc1_pic_state(VADriverContextP ctx,
     assert(pic_param->picture_fields.bits.frame_coding_mode < 3);
 
     if (pic_param->sequence_fields.bits.interlace) {
-        if (!pic_param->picture_fields.bits.top_field_first)
-            fcm = 3;
-        else
+        if (pic_param->picture_fields.bits.frame_coding_mode < 2)
             fcm = pic_param->picture_fields.bits.frame_coding_mode;
+        else if (!pic_param->picture_fields.bits.top_field_first)
+            fcm = 3; /* Field with bottom field first */
+        else
+            fcm = 2; /* Field with top field first */
     }
 
     if (pic_param->sequence_fields.bits.interlace &&


### PR DESCRIPTION
Some VC1 clips might be marked interlaced but have fcm < 2, and the
wrong fcm will lead to undefined behavior, such as GPU hang.

This fixes https://github.com/01org/intel-vaapi-driver/issues/316

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>