### PR TITLE
ENC/jpeg: fix regression with Small optimization

### DIFF
--- a/src/gen8_mfc.c
+++ b/src/gen8_mfc.c
@@ -2840,8 +2840,8 @@ get_reciprocal_dword_qm(unsigned char *raster_qm, uint32_t *dword_qm)
     short hdw, ldw;
 
     for (i = 0, j = 0; i < 64; i += 2, j++) {
-        hdw = 65535 / (raster_qm[i]);
-        ldw = 65535 / (raster_qm[i + 1]);
+        ldw = 65535 / (raster_qm[i]);
+        hdw = 65535 / (raster_qm[i + 1]);
         dword_qm[j] = (hdw << 16) | ldw;
     }
 }


### PR DESCRIPTION
This fixes 6c1b9b345982babde748518de1834e2af8bcf321:
Small optimization while removing warning

The higher 16 bit of dword_qm[j] (j = 0, 1, ..., 31) is
65535 / (raster_qm[i + 1]) (i = 0, 2, 4, ..., 62)

This fixes https://github.com/01org/intel-vaapi-driver/issues/319

Signed-off-by: Xiang, Haihao <haihao.xiang@intel.com>