### PR TITLE
ENC:fix  the regression by min resolution check for encoder

### DIFF
--- a/src/i965_drv_video.h
+++ b/src/i965_drv_video.h
@@ -81,6 +81,7 @@
 #define ENCODER_HIGH_QUALITY      ENCODER_DEFAULT_QUALITY
 #define ENCODER_LOW_QUALITY       2
 
+#define I965_MIN_CODEC_ENC_RESOLUTION_WIDTH_HEIGHT   32
 #define I965_MAX_NUM_ROI_REGIONS                     8
 #define I965_MAX_NUM_SLICE                           32
 

--- a/src/i965_encoder.c
+++ b/src/i965_encoder.c
@@ -824,12 +824,12 @@ intel_encoder_check_misc_parameter(VADriverContextP ctx,
 {
     struct i965_driver_data *i965 = i965_driver_data(ctx);
     VAStatus ret = VA_STATUS_SUCCESS;
-    int min_width_height = 32;
+    int min_width_height = I965_MIN_CODEC_ENC_RESOLUTION_WIDTH_HEIGHT;
 
     if (encoder_context->frame_width_in_pixel > 0 &&
         encoder_context->frame_height_in_pixel > 0) {
         if (profile == VAProfileJPEGBaseline)
-            min_width_height = 16;
+            min_width_height = 1;
         if (encoder_context->frame_width_in_pixel < min_width_height ||
             encoder_context->frame_height_in_pixel < min_width_height)
             return VA_STATUS_ERROR_INVALID_PARAMETER;

--- a/test/i965_avce_context_test.cpp
+++ b/test/i965_avce_context_test.cpp
@@ -77,6 +77,7 @@ protected:
     VAConfigID      config = VA_INVALID_ID;
     VAContextID     context = VA_INVALID_ID;
     bool            is_gen9 = false;
+    int             min_resolution_width_height = I965_MIN_CODEC_ENC_RESOLUTION_WIDTH_HEIGHT;
 };
 
 TEST_P(AVCEContextTest, RateControl)
@@ -115,7 +116,11 @@ TEST_P(AVCEContextTest, RateControl)
         config = createConfig(profile, entrypoint, attribs, expect);
         if (expect != VA_STATUS_SUCCESS) continue;
 
-        context = createContext(config, 1, 1);
+        context = createContext(
+            config,
+            min_resolution_width_height,
+            min_resolution_width_height);
+
         if (HasFailure()) continue;
 
         struct intel_encoder_context const *hw_context(*this);
@@ -150,7 +155,10 @@ TEST_P(AVCEContextTest, Codec)
 
     ASSERT_NO_FAILURE(
         config = createConfig(profile, entrypoint);
-        context = createContext(config, 1, 1);
+        context = createContext(
+            config,
+            min_resolution_width_height,
+            min_resolution_width_height);
     );
 
     struct intel_encoder_context const *hw_context(*this);
@@ -170,7 +178,10 @@ TEST_P(AVCEContextTest, LowPowerMode)
 
     ASSERT_NO_FAILURE(
         config = createConfig(profile, entrypoint);
-        context = createContext(config, 1, 1);
+        context = createContext(
+            config,
+            min_resolution_width_height,
+            min_resolution_width_height);
     );
 
     struct intel_encoder_context const *hw_context(*this);
@@ -195,7 +206,10 @@ TEST_P(AVCEContextTest, ROINotSpecified)
     // will disable it.
     ASSERT_NO_FAILURE(
         config = createConfig(profile, entrypoint);
-        context = createContext(config, 1, 1);
+        context = createContext(
+            config,
+            min_resolution_width_height,
+            min_resolution_width_height);
     );
 
     struct intel_encoder_context const *hw_context(*this);
@@ -224,7 +238,10 @@ TEST_P(AVCEContextTest, ROISpecified)
     ConfigAttribs attribs(1, {type:VAConfigAttribEncROI});
     ASSERT_NO_FAILURE(
         config = createConfig(profile, entrypoint, attribs);
-        context = createContext(config, 1, 1);
+        context = createContext(
+            config,
+            min_resolution_width_height,
+            min_resolution_width_height);
     );
 
     struct intel_encoder_context const *hw_context(*this);
@@ -244,7 +261,10 @@ TEST_P(AVCEContextTest, QualityRange)
 
     ASSERT_NO_FAILURE(
         config = createConfig(profile, entrypoint);
-        context = createContext(config, 1, 1);
+        context = createContext(
+            config,
+            min_resolution_width_height,
+            min_resolution_width_height);
     );
 
     struct intel_encoder_context const *hw_context(*this);


### PR DESCRIPTION
JPEG encoder allow min resolution 1x1
add min resolution check in vaCreateContext to avoid gtest failture
add fix for gtest case
fix the regression in 88249259d4abb2fd701ed3db229941738da2497e

Fixes #330 #333
Signed-off-by: Pengfei Qu <Pengfei.Qu@intel.com>