### PR TITLE
test/avce_context: update RC expectation for Stats entrypoint

### DIFF
--- a/test/i965_avce_context_test.cpp
+++ b/test/i965_avce_context_test.cpp
@@ -100,7 +100,7 @@ TEST_P(AVCEContextTest, RateControl)
         {VAEntrypointEncSlice, i965->codec_info->h264_brc_mode},
         {VAEntrypointEncSliceLP, i965->codec_info->lp_h264_brc_mode},
         {VAEntrypointFEI, VA_RC_CQP},
-        {VAEntrypointStats, VA_RC_NONE},
+        {VAEntrypointStats, VA_ATTRIB_NOT_SUPPORTED},
     };
 
     for (auto rc : rateControls) {


### PR DESCRIPTION
Rate control attribute is unsupported for AVCE VAEntrypointStats.

This fixes the following test regressions since 336d8913aa30:

AVCEncode/AVCEContextTest.RateControl/3, where GetParam()
  = (VAProfileH264ConstrainedBaseline, VAEntrypointStats)

AVCEncode/AVCEContextTest.RateControl/7, where GetParam()
  = (VAProfileH264Main, VAEntrypointStats)

AVCEncode/AVCEContextTest.RateControl/11, where GetParam()
  = (VAProfileH264High, VAEntrypointStats)

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>